### PR TITLE
Add in memory option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM java:jre-alpine
 MAINTAINER Sascha Hanse <shanse@gmail.com>
 LABEL app="datastore-emulator"
 
+ENV IN_MEMORY "false"
 ENV CLOUDSDK_CORE_DISABLE_PROMPTS 1
 ENV DATA_DIR "/opt/datastore"
 ENV HOST_PORT 8432

--- a/start_datastore_emu.sh
+++ b/start_datastore_emu.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-/root/google-cloud-sdk/bin/gcloud beta emulators datastore start --data-dir "${DATA_DIR}" --host-port "0.0.0.0:${HOST_PORT}" --consistency="${CONSISTENCY}"
+if [ "$IN_MEMORY" = "true" ]; then
+  /root/google-cloud-sdk/bin/gcloud beta emulators datastore start --no-store-on-disk --host-port "0.0.0.0:${HOST_PORT}" --consistency="${CONSISTENCY}"
+else
+  /root/google-cloud-sdk/bin/gcloud beta emulators datastore start --data-dir "${DATA_DIR}" --host-port "0.0.0.0:${HOST_PORT}" --consistency="${CONSISTENCY}"
+
+fi


### PR DESCRIPTION
We are using this container for our CI pipeline, and we would like to use the /reset endpoint between tests to clear the datastore completely. Unfortunately, this only works when the emulator uses the in-memory implementation.

This change adds an environment variable IN_MEMORY that can be set to "true" to make the emulator run in this mode.